### PR TITLE
Add a change to kata_setup to copy the assets to home directory

### DIFF
--- a/master-course-data/assets/tools/kata_setup.sh
+++ b/master-course-data/assets/tools/kata_setup.sh
@@ -10,3 +10,10 @@ if [ "$ret" == 0 ]; then
 else
     echo "Something wrong ... please try again X("
 fi
+
+# This is workaround for https://github.com/irixjp/katacoda-scenarios/issues/6.
+cd ~/katacoda-scenarios/master-course-data/assets/
+cp -a tools/kata_prepare.yml ~/
+cp -a tools/.ansible.cfg ~/
+cp -a working/ ~/working/
+cd ~/


### PR DESCRIPTION
It looks like katacoda's assets feature isn't working, so I added a workaround to kata_setup.sh that copies assets to home directory.